### PR TITLE
SAMLRequest should not be an int

### DIFF
--- a/src/eduid_idp/tests/test_SSOLoginData.py
+++ b/src/eduid_idp/tests/test_SSOLoginData.py
@@ -41,14 +41,14 @@ import eduid_idp
 class TestSSOLoginData(TestCase):
 
     def test_FailCount(self):
-        data = {'SAMLRequest': 4711,
+        data = {'SAMLRequest': '4711',
                 }
         ticket = eduid_idp.login.SSOLoginData('key', 'req_info', data, 'binding')
         ticket.FailCount = 9
         self.assertEqual(ticket.FailCount, 9)
 
     def test_SAMLRequest(self):
-        data = {'SAMLRequest': 4711,
+        data = {'SAMLRequest': '4711',
                 }
         ticket = eduid_idp.login.SSOLoginData('key', 'req_info', data, 'binding')
-        self.assertEqual(ticket.SAMLRequest, 4711)
+        self.assertEqual(ticket.SAMLRequest, '4711')


### PR DESCRIPTION
While adding the new code to escape strings to counter xss I noticed that SAMLRequest is tested with and integer value. However according to the documentation and the return value of the function SAMLRequest are base64 encoded strings.