### PR TITLE
Remove dependency on html5.js (that we fetched over http)

### DIFF
--- a/static/login.html
+++ b/static/login.html
@@ -6,10 +6,6 @@
     <title>eduID login</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!--[if lt IE 9]>
-    <script src="http://html5shiv.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
-
     <link href="/static/css/bootstrap-3.2.0.min.css" rel="stylesheet" media="screen">
   </head>
   <body>


### PR DESCRIPTION
since we do not support anything less than IE9 in our cipher setting anyway,
we can remove this external dependency.