### PR TITLE
getLastError is no longer (has never been?) a valid argument

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ import os
 here = os.path.abspath(os.path.dirname(__file__))
 README = open(os.path.join(here, 'README')).read()
 
-version = '0.5.3b0'
+version = '0.5.3b1'
 
 install_requires = [
     'eduid_userdb >= 0.3.0',

--- a/src/eduid_idp/cache.py
+++ b/src/eduid_idp/cache.py
@@ -437,7 +437,7 @@ class SSOSessionCacheMDB(SSOSessionCache):
                 self.logger.error('Failed ensuring mongodb index, retrying ({!r})'.format(e))
 
     def remove_session(self, sid):
-        res = self.sso_sessions.remove({'session_id': sid}, w = 1, getLastError = True)
+        res = self.sso_sessions.remove({'session_id': sid}, w = 'majority')
         try:
             return res['n']  # number of deleted records
         except (KeyError, TypeError):


### PR DESCRIPTION
setting w to majority if we ever use more than three mongo servers