### PR TITLE
add IdPContext

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ metadata.xml
 .idea
 .*.swp
 revision.txt
+.mypy_cache

--- a/.jenkins.yaml
+++ b/.jenkins.yaml
@@ -16,11 +16,12 @@ publish_over_ssh:
   - pypi.sunet.se
 
 script:
-  - "virtualenv -p python3 venv"
+  - "python3.7 -m venv venv"
   - ". venv/bin/activate"
-  - "pip install --upgrade setuptools pip wheel"
+  - "pip install --upgrade setuptools pip wheel mypy"
   - "pip install --index-url https://pypi.sunet.se -r test_requirements.txt"
   - "nosetests"
+  - "mypy --ignore-missing-imports src/eduid_idp"
   - "python setup.py sdist bdist_wheel --universal"
 
 extra_jobs:

--- a/src/eduid_idp/config.py
+++ b/src/eduid_idp/config.py
@@ -37,10 +37,7 @@ Configuration (file) handling for eduID IdP.
 
 import six
 import os
-try:
-    import configparser
-except:
-    from six.moves import configparser
+from six.moves import configparser
 
 import nacl.secret
 from base64 import urlsafe_b64decode

--- a/src/eduid_idp/context.py
+++ b/src/eduid_idp/context.py
@@ -1,0 +1,24 @@
+"""
+A context for the IdP.
+"""
+
+from dataclasses import dataclass
+from typing import Optional
+from logging import Logger
+
+from eduid_idp.config import IdPConfig
+from eduid_idp.loginstate import SSOLoginDataCache
+
+from eduid_userdb.actions import ActionDB
+
+from saml2.server import Server as Saml2Server
+
+
+@dataclass(frozen=True)
+class IdPContext(object):
+    config: IdPConfig
+    sessions: SSOLoginDataCache
+    idp: Saml2Server
+    logger: Logger
+    actions_db: Optional[ActionDB]
+

--- a/src/eduid_idp/idp.py
+++ b/src/eduid_idp/idp.py
@@ -196,6 +196,9 @@ class IdPApplication(object):
 
         self._init_pysaml2()
 
+        _login_state_ttl = (self.config.login_state_ttl + 1) * 60
+        self.sessions = SSOLoginDataCache(self.IDP, 'TicketCache', self.logger, _login_state_ttl,
+                                          self.config, threading.Lock())
         self.authn_info_db = None
         self.actions_db = None
 
@@ -260,10 +263,6 @@ class IdPApplication(object):
         finally:
             # restore path
             sys.path = old_path
-
-        _login_state_ttl = (self.config.login_state_ttl + 1) * 60
-        self.IDP.ticket = SSOLoginDataCache(self.IDP, 'TicketCache', self.logger, _login_state_ttl,
-                                            self.config, threading.Lock())
 
     @cherrypy.expose
     def sso(self, *_args, **_kwargs):

--- a/src/eduid_idp/idp.py
+++ b/src/eduid_idp/idp.py
@@ -117,12 +117,16 @@ import cherrypy
 import simplejson
 
 import logging.handlers
+from logging import Logger
+from typing import Optional, Any
 
 import eduid_idp
 import eduid_idp.authn
 import eduid_idp.sso_session
 from eduid_idp.login import SSO
 from eduid_idp.logout import SLO
+from eduid_idp.config import IdPConfig
+from eduid_idp.context import IdPContext
 from eduid_idp.loginstate import SSOLoginDataCache
 
 from eduid_userdb.actions import ActionDB
@@ -177,6 +181,8 @@ class IdPApplication(object):
     """
     Main CherryPy application for the eduid IdP.
 
+    Userdb can be passed as an argument to make testing easier.
+
     :param logger: logging logger
     :param config: IdP configuration data
 
@@ -184,7 +190,7 @@ class IdPApplication(object):
     :type config: eduid_idp.config.IdPConfig
     """
 
-    def __init__(self, logger, config):
+    def __init__(self, logger: Logger, config: IdPConfig, userdb: Optional[Any] = None):
         self.logger = logger
         self.config = config
         self.response_status = None
@@ -197,16 +203,16 @@ class IdPApplication(object):
         self._init_pysaml2()
 
         _login_state_ttl = (self.config.login_state_ttl + 1) * 60
-        self.sessions = SSOLoginDataCache(self.IDP, 'TicketCache', self.logger, _login_state_ttl,
-                                          self.config, threading.Lock())
+        _sessions = SSOLoginDataCache(self.IDP, 'TicketCache', self.logger, _login_state_ttl,
+                                      self.config, threading.Lock())
         self.authn_info_db = None
-        self.actions_db = None
+        _actions_db = None
 
         if config.mongo_uri:
             self.authn_info_db = eduid_idp.authn.AuthnInfoStoreMDB(config.mongo_uri, logger)
 
         if config.mongo_uri and config.actions_auth_shared_secret and config.actions_app_uri:
-            self.actions_db = ActionDB(config.mongo_uri)
+            _actions_db = ActionDB(config.mongo_uri)
             self.logger.info("configured to redirect users with pending actions")
 
             from importlib import import_module
@@ -220,7 +226,9 @@ class IdPApplication(object):
         else:
             self.logger.debug("NOT configured to redirect users with pending actions")
 
-        self.userdb = eduid_idp.idp_user.IdPUserDb(logger, config)
+        if userdb is None:
+            userdb = eduid_idp.idp_user.IdPUserDb(logger, config)
+        self.userdb = userdb
         self.authn = eduid_idp.authn.IdPAuthn(logger, config, self.userdb)
 
         cherrypy.config.update({'request.error_response': self.handle_error,
@@ -234,6 +242,13 @@ class IdPApplication(object):
         else:  # IPv4
             listen_str += self.config.listen_addr + ':' + str(self.config.listen_port)
         self.logger.info("eduid-IdP server started, listening on {!s}".format(listen_str))
+
+        self.context = IdPContext(config=self.config,
+                                  idp=self.IDP,
+                                  logger=self.logger,
+                                  sessions=_sessions,
+                                  actions_db=_actions_db,
+                                  )
 
     def _init_pysaml2(self):
         """
@@ -274,9 +289,9 @@ class IdPApplication(object):
         session = self._lookup_sso_session()
 
         if path[1] == 'post':
-            return SSO(session, self._my_start_response, self).post()
+            return SSO(session, self._my_start_response, self.context).post()
         if path[1] == 'redirect':
-            return SSO(session, self._my_start_response, self).redirect()
+            return SSO(session, self._my_start_response, self.context).redirect()
 
         raise eduid_idp.error.NotFound(logger = self.logger)
 
@@ -290,12 +305,12 @@ class IdPApplication(object):
         session = self._lookup_sso_session()
 
         if path[1] == 'post':
-            return SLO(session, self._my_start_response, self).post()
+            return SLO(session, self._my_start_response, self.context).post()
         if path[1] == 'redirect':
-            return SLO(session, self._my_start_response, self).redirect()
+            return SLO(session, self._my_start_response, self.context).redirect()
         if path[1] == 'soap':
             # SOAP is commonly used for SLO
-            return SLO(session, self._my_start_response, self).soap()
+            return SLO(session, self._my_start_response, self.context).soap()
 
         raise eduid_idp.error.NotFound(logger = self.logger)
 
@@ -311,7 +326,7 @@ class IdPApplication(object):
             #raise eduid_idp.error.LoginTimeout("Already logged in - can't verify credentials again",
             #                                   logger = self.logger)
             self.logger.debug("User is already logged in - verifying credentials again might not work")
-        return eduid_idp.login.do_verify(idp_app = self)
+        return eduid_idp.login.do_verify(self.context, self.authn)
 
     @cherrypy.expose
     def static(self, *_args, **_kwargs):

--- a/src/eduid_idp/idp_actions.py
+++ b/src/eduid_idp/idp_actions.py
@@ -33,7 +33,6 @@
 #
 
 
-import six
 from importlib import import_module
 
 import eduid_idp.util

--- a/src/eduid_idp/idp_actions.py
+++ b/src/eduid_idp/idp_actions.py
@@ -39,38 +39,36 @@ import eduid_idp.util
 import eduid_idp.mischttp
 
 from eduid_idp.authn import AuthnData
+from eduid_idp.idp_user import IdPUser
+from eduid_idp.context import IdPContext
+from eduid_idp.loginstate import SSOLoginData
+from eduid_idp.sso_session import SSOSession
 from eduid_common.authn.utils import generate_auth_token
 
 
-def check_for_pending_actions(idp_app, user, ticket, sso_session):
+def check_for_pending_actions(context: IdPContext, user: IdPUser, ticket: SSOLoginData,
+                              sso_session: SSOSession) -> None:
     """
     Check whether there are any pending actions for the current user,
     and if there are, redirect to the actions app.
 
     The redirection is performed by raising an eduid_idp.mischttp.Redirect.
 
-    :param idp_app: IdP application instance
+    :param context: IdP application instance
     :param user: the authenticating user
     :param ticket: SSOLoginData instance
     :param sso_session: SSOSession
-
-    :type user: eduid_idp.idp_user.IdPUser
-    :type idp_app: eduid_idp.idp.IdPApplication
-    :type ticket: eduid_idp.loginstate.SSOLoginData
-    :type sso_session: eduid_idp.sso_session.SSOSession
-
-    :rtype: None
     """
 
-    if idp_app.actions_db is None:
-        idp_app.logger.info("This IdP is not initialized for special actions")
+    if context.actions_db is None:
+        context.logger.info("This IdP is not initialized for special actions")
         return
 
     # Add any actions that may depend on the login data
-    add_idp_initiated_actions(idp_app, user, ticket)
+    add_idp_initiated_actions(context, user, ticket)
 
-    actions_eppn = idp_app.actions_db.get_actions(user.eppn, session = ticket.key)
-    actions_userid = idp_app.actions_db.get_actions(user.user_id, session = ticket.key)
+    actions_eppn = context.actions_db.get_actions(user.eppn, session = ticket.key)
+    actions_userid = context.actions_db.get_actions(user.user_id, session = ticket.key)
 
     # Check for pending actions
     pending_actions = [a for a in actions_eppn if a.result is None]
@@ -85,20 +83,20 @@ def check_for_pending_actions(idp_app, user, ticket, sso_session):
             update = True
 
         if update:
-            idp_app.IDP.cache.update_session(user.user_id, sso_session.to_dict())
+            context.idp.cache.update_session(user.user_id, sso_session.to_dict())
 
-        idp_app.logger.debug('There are no pending actions for user {}'.format(user))
+        context.logger.debug('There are no pending actions for user {}'.format(user))
         return
 
     # Pending actions found, redirect to the actions app
-    idp_app.logger.debug('There are pending actions for user {}: {}'.format(user, pending_actions))
+    context.logger.debug('There are pending actions for user {}: {}'.format(user, pending_actions))
 
     # create auth token for actions app
-    shared_key = idp_app.config.actions_auth_shared_secret.decode('utf-8')
+    shared_key = context.config.actions_auth_shared_secret.decode('utf-8')
     auth_token, timestamp = generate_auth_token(shared_key, 'idp_actions', user.eppn)
 
-    actions_uri = idp_app.config.actions_app_uri
-    idp_app.logger.info("Redirecting user {!s} to actions app {!s}".format(user, actions_uri))
+    actions_uri = context.config.actions_app_uri
+    context.logger.info("Redirecting user {!s} to actions app {!s}".format(user, actions_uri))
 
     # XXX this leaves the ticket.key vulnerable to manipulation -
     # better move it inside the secret box when we can remove the backwards compat HMAC code

--- a/src/eduid_idp/login.py
+++ b/src/eduid_idp/login.py
@@ -59,6 +59,7 @@ class SSO(Service):
 
     def __init__(self, session, start_response, idp_app):
         Service.__init__(self, session, start_response, idp_app)
+        self._sessions = idp_app.sessions
         self._idp_app = idp_app
 
     def perform_login(self, ticket):
@@ -357,7 +358,7 @@ class SSO(Service):
         _info = self.unpack_redirect()
         self.logger.debug("Unpacked redirect :\n{!s}".format(pprint.pformat(_info)))
 
-        ticket = self.IDP.ticket.get_ticket(_info, binding=BINDING_HTTP_REDIRECT)
+        ticket = self._sessions.get_ticket(_info, binding=BINDING_HTTP_REDIRECT)
         return self._redirect_or_post(ticket)
 
     def post(self):
@@ -370,7 +371,7 @@ class SSO(Service):
         self.logger.debug("--- In SSO POST ---")
         _info = self.unpack_either()
 
-        ticket = self.IDP.ticket.get_ticket(_info, binding=BINDING_HTTP_POST)
+        ticket = self._sessions.get_ticket(_info, binding=BINDING_HTTP_POST)
         return self._redirect_or_post(ticket)
 
     def _redirect_or_post(self, ticket):
@@ -534,7 +535,7 @@ def do_verify(idp_app):
         _loggable['password'] = '<redacted>'
     idp_app.logger.debug("do_verify parsed query :\n{!s}".format(pprint.pformat(_loggable)))
 
-    _ticket = idp_app.IDP.ticket.get_ticket(query)
+    _ticket = idp_app.sessions.get_ticket(query)
 
     authn_ref = None
     if _ticket.req_info.message.requested_authn_context:

--- a/src/eduid_idp/loginstate.py
+++ b/src/eduid_idp/loginstate.py
@@ -156,6 +156,7 @@ class SSOLoginDataCache(object):
         if (config.redis_sentinel_hosts or config.redis_host) and config.session_app_key:
             self._cache = eduid_idp.cache.ExpiringCacheCommonSession(name, logger, ttl, config)
         else:
+            # This is used in tests
             self._cache = eduid_idp.cache.ExpiringCacheMem(name, logger, ttl, lock)
         logger.debug('Set up IDP ticket cache {!s}'.format(self._cache))
 

--- a/src/eduid_idp/service.py
+++ b/src/eduid_idp/service.py
@@ -14,6 +14,7 @@ Common code for SSO login/logout requests.
 """
 
 import eduid_idp.mischttp
+from eduid_idp.context import IdPContext
 
 
 class Service(object):
@@ -26,15 +27,15 @@ class Service(object):
 
     :type session: SSOSession | None
     :type start_response: function
-    :type idp_app: idp.IdPApplication
     """
 
-    def __init__(self, session, start_response, idp_app):
+    def __init__(self, session, start_response, context: IdPContext):
+        self.context = context
         self.start_response = start_response
-        self.logger = idp_app.logger
-        self.IDP = idp_app.IDP
-        self.config = idp_app.config
         self.sso_session = session
+        # TODO: Get rid of this copying of things in the context
+        self.logger = context.logger
+        self.config = context.config
 
     def unpack_redirect(self):
         """

--- a/src/eduid_idp/testing.py
+++ b/src/eduid_idp/testing.py
@@ -160,6 +160,7 @@ class FakeIdPApp(IdPApplication):
         self.IDP = server.Server(config_file=config_file)
         self.config = {}
         self.IDP.metadata = FakeMetadata()
+        self.sessions = None
 
 
 class IdPSimpleTestCase(TestCase):

--- a/src/eduid_idp/tests/test_actions.py
+++ b/src/eduid_idp/tests/test_actions.py
@@ -64,7 +64,7 @@ remote = cherrypy.lib.httputil.Host('127.0.0.1', 50001, "")
 class TestActions(MongoTestCase):
 
     def setUp(self):
-        super(TestActions, self).setUp()
+        super().setUp()
 
         # load the IdP configuration
         datadir = pkg_resources.resource_filename(__name__, 'data')
@@ -77,7 +77,7 @@ class TestActions(MongoTestCase):
         # Create the IdP app
         self.idp_app = IdPApplication(logger, self.config)
 
-        self.actions = self.idp_app.actions_db
+        self.actions = self.idp_app.context.actions_db
 
         # setup some test data
         _email = 'johnsmith@example.com'

--- a/src/eduid_idp/tests/test_actions.py
+++ b/src/eduid_idp/tests/test_actions.py
@@ -152,7 +152,7 @@ class TestActions(MongoTestCase):
         self.assertEqual(resp.status, '200 Ok')
         self.assertIn(six.b('action="https://sp.example.edu/saml2/acs/"'), resp.body)
 
-    def test_action(self):
+    def test_action_2(self):
 
         # make the SAML authn request
         req = make_SAML_request(PASSWORDPROTECTEDTRANSPORT)


### PR DESCRIPTION
    Put the things we need 'everywhere' in a separate context dataclass
    and pass that down the stack rather than passing the top-level
    IdPApplication.

    This gives us the possiblity to do type checking without getting
    circular imports where IdPApplication imports 'a' and 'a' imports
    IdPApplication in order to verify it's type.

    It should also make it easier to do the rewrite when moving from
    CherryPy to Flask.