### PR TITLE
decouple the authn module from cherrypy

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 eduid_userdb>=0.4.6b9
-eduid_common[idp]>=0.4.1b19
+eduid_common[idp]>=0.4.1b20
 pysaml2==4.8.0
 cherrypy==15.0
 defusedxml>=0.5.0

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ import os
 here = os.path.abspath(os.path.dirname(__file__))
 README = open(os.path.join(here, 'README')).read()
 
-version = '0.5.9b7'
+version = '0.5.9b8'
 
 install_requires = [x for x in open(os.path.join(here, 'requirements.txt')).read().split('\n') if len(x) > 0]
 testing_extras = [x for x in open(os.path.join(here, 'test_requirements.txt')).read().split('\n')

--- a/src/eduid_idp/authn.py
+++ b/src/eduid_idp/authn.py
@@ -40,8 +40,8 @@ such as rate limiting.
 import datetime
 from typing import Optional
 
-import eduid_idp.error
 import vccs_client
+from eduid_common.api import exceptions
 from eduid_common.authn.idp_authn import AuthnData, AuthnInfoStoreMDB
 from eduid_common.authn import get_vccs_client
 from eduid_userdb.credentials import Password
@@ -118,7 +118,7 @@ class IdPAuthn(object):
             if authn_info.failures_this_month() > self.config.max_authn_failures_per_month:
                 self.logger.info("User {!r} AuthN failures this month {!r} > {!r}".format(
                     user, authn_info.failures_this_month(), self.config.max_authn_failures_per_month))
-                raise eduid_idp.error.TooManyRequests("Too Many Requests")
+                raise exceptions.EduidTooManyRequests("Too Many Requests")
 
             # Optimize list of credentials to try based on which credentials the
             # user used in the last successful authentication. This optimization
@@ -164,7 +164,7 @@ class IdPAuthn(object):
                     # (Kantara AL2_CM_CSM#050).
                     if self.credential_expired(cred):
                         self.logger.info('User {} credential {!r} has expired'.format(user, cred.key))
-                        raise eduid_idp.error.Forbidden('CREDENTIAL_EXPIRED')
+                        raise exceptions.EduidForbidden('CREDENTIAL_EXPIRED')
                     self.log_authn(user, success=[cred.credential_id], failure=[])
                     return cred
             except vccs_client.VCCSClientHTTPError as exc:

--- a/src/eduid_idp/tests/test_idPUserDb.py
+++ b/src/eduid_idp/tests/test_idPUserDb.py
@@ -43,6 +43,7 @@ import eduid_idp
 import eduid_userdb
 import eduid_common.authn
 import vccs_client
+from eduid_common.api import exceptions
 
 from eduid_userdb.testing import MongoTestCase
 from eduid_common.session.testing import RedisTemporaryInstance
@@ -155,10 +156,10 @@ class TestAuthentication(MongoTestCase):
         # Store a successful authentication using this credential three year ago
         three_years_ago = datetime.datetime.now() - datetime.timedelta(days = 3 * 365)
         self.idp_app.authn.authn_store.credential_success([passwords[0].key], three_years_ago)
-        with self.assertRaises(eduid_idp.error.Forbidden):
+        with self.assertRaises(exceptions.EduidForbidden):
             self.assertTrue(self.idp_app.authn.password_authn(data))
         # Do the same thing again to make sure we didn't accidentally update the
         # 'last successful login' timestamp when it was a successful login with an
         # expired credential.
-        with self.assertRaises(eduid_idp.error.Forbidden):
+        with self.assertRaises(exceptions.EduidForbidden):
             self.assertTrue(self.idp_app.authn.password_authn(data))


### PR DESCRIPTION
decouple the eduid_idp.authn module from cherrypy, to be able to move it to eduid-common